### PR TITLE
Add Crewed supersonic science to cockpits (#99)

### DIFF
--- a/GameData/KerbalismConfig/System/Science/Configure.cfg
+++ b/GameData/KerbalismConfig/System/Science/Configure.cfg
@@ -472,6 +472,84 @@
 // Crew experiment Selection
 // ============================================================================
 
+// Cockpits
+@PART[*]:HAS[#capsuleTier[Cockpit]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
+{
+	@MODULE[HardDrive]
+	{
+		@sampleCapacity += 1
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Crew Science
+		slots = 1
+		
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = Supersonic flight
+			desc = //fixme
+			mass = 0.004
+			
+			MODULE
+			{
+			  type = Experiment
+			  id_field = experiment_id
+			  id_value = RP0-SupersonicLow1
+			}
+		}
+		SETUP
+		{
+			name = Mach 2 flight
+			desc = //fixme
+			mass = 0.004
+			tech = supersonicDev
+			
+			MODULE
+			{
+			  type = Experiment
+			  id_field = experiment_id
+			  id_value = RP0-SupersonicLow2
+			}
+		}
+		SETUP
+		{
+			name = High altitude flight
+			desc = //fixme
+			mass = 0.004
+			tech = supersonicFlightRP0
+			
+			MODULE
+			{
+			  type = Experiment
+			  id_field = experiment_id
+			  id_value = RP0-SupersonicHigh1
+			}
+		}
+		SETUP
+		{
+			name = Hypersonic flight
+			desc = //fixme
+			mass = 0.004
+			tech = supersonicFlightRP0
+			
+			MODULE
+			{
+			  type = Experiment
+			  id_field = experiment_id
+			  id_value = RP0-SupersonicHigh2
+			}
+		}
+	}
+}
+
 // Basic Capsules
 @PART[*]:HAS[#capsuleTier[Basic]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
 {

--- a/GameData/KerbalismConfig/System/Science/CrewScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/ExperimentValues.cfg
@@ -1,5 +1,50 @@
 KERBALISM_CREW_EXPERIMENTS
 {
+	// Cockpits
+	RP0-SupersonicLow1
+    {
+        ECCost = 0
+		SampleMass = 0.002
+        size =  0.02
+		value = 15000 // 15 science
+		duration = 1500 //25 minutes, requires 5 flights
+		requirements = CrewMin:1,SurfaceSpeedMin:300,AltitudeMin:10000
+		ResourceRates = 
+		IncludeExperiment = 
+	}
+	RP0-SupersonicLow2
+    {
+        ECCost = 0
+		SampleMass = 0.002
+        size =  0.02
+		value = 20000 // 20 science
+		duration = 2400 //40 minutes, requires 5 flights
+		requirements = CrewMin:1,SurfaceSpeedMin:600,AltitudeMin:10000
+		ResourceRates = 
+		IncludeExperiment = 
+	}
+	RP0-SupersonicHigh1
+    {
+        ECCost = 0
+		SampleMass = 0.002
+        size =  0.02
+		value = 20 // 20 science
+		duration = 2400 //40 minutes, requires 5 flights
+		requirements = CrewMin:1,SurfaceSpeedMin:650
+		ResourceRates = 
+		IncludeExperiment = 
+	}
+	RP0-SupersonicHigh2
+    {
+        ECCost = 0
+		SampleMass = 0.002
+        size =  0.02
+		value = 20 // 20 science
+		duration = 2400 //40 minutes, requires 5 flights
+		requirements = CrewMin:1,SurfaceSpeedMin:1620
+		ResourceRates = 
+		IncludeExperiment = 
+	}
 	// Early Capsules
 	RP0-LiquidsMicrogravity
 	{

--- a/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/CockpitExperiments.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/CockpitExperiments.cfg
@@ -1,0 +1,156 @@
+// ============================================================================
+// Add tag to parts
+// ============================================================================
+@PART[SXTBuzzard|SXTke111|SXTClyde|SXTmk3Cockpit52|625mBonny|25mKossak|SXTOsaulNoseCockpitAn225|SXTOsualRadCockpit|RP0Nose-Cockpit|X1-Crew|Mark1Cockpit|Mark2Cockpit|RO-X1Cockpit]:NEEDS[FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism]
+{
+	%capsuleTier = Cockpit
+}
+
+// ============================================================================
+// Supersonic low 1
+// ============================================================================
+@PART[*]:HAS[#capsuleTier[Cockpit]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0-SupersonicLow1
+
+		ec_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/ECCost$
+		%sample_amount = 0.2
+		data_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/size$
+		@data_rate /= #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/duration$
+		requires = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/requirements$
+		resources = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/ResourceRates$
+        
+		crew_operate = True
+		hide_when_unavailable = True
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[RP0-SupersonicLow1]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	@baseValue = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/value$
+	@dataScale = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+  	{
+   		// sample mass in tons. if undefined or 0, the experiment produce a file
+    	SampleMass = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/SampleMass$
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
+		IncludeExperiment = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow1/IncludeExperiment$
+ 	}
+}
+
+// ============================================================================
+// Supersonic low 2
+// ============================================================================
+@PART[*]:HAS[#capsuleTier[Cockpit]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0-SupersonicLow2
+
+		ec_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/ECCost$
+		%sample_amount = 0.2
+		data_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/size$
+		@data_rate /= #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/duration$
+		requires = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/requirements$
+		resources = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/ResourceRates$
+        
+		crew_operate = True
+		hide_when_unavailable = True
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[RP0-SupersonicLow2]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	@baseValue = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/value$
+	@dataScale = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+  	{
+   		// sample mass in tons. if undefined or 0, the experiment produce a file
+    	SampleMass = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/SampleMass$
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
+		IncludeExperiment = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicLow2/IncludeExperiment$
+ 	}
+}
+
+// ============================================================================
+// Supersonic high 1
+// ============================================================================
+@PART[*]:HAS[#capsuleTier[Cockpit]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0-SupersonicHigh1
+
+		ec_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/ECCost$
+		%sample_amount = 0.2
+		data_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/size$
+		@data_rate /= #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/duration$
+		requires = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/requirements$
+		resources = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/ResourceRates$
+        
+		crew_operate = True
+		hide_when_unavailable = True
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[RP0-SupersonicHigh1]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	@baseValue = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/value$
+	@dataScale = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+  	{
+   		// sample mass in tons. if undefined or 0, the experiment produce a file
+    	SampleMass = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/SampleMass$
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
+		IncludeExperiment = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh1/IncludeExperiment$
+ 	}
+}
+
+// ============================================================================
+// Supersonic high 2
+// ============================================================================
+@PART[*]:HAS[#capsuleTier[Cockpit]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0-SupersonicHigh2
+
+		ec_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/ECCost$
+		%sample_amount = 0.2
+		data_rate = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/size$
+		@data_rate /= #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/duration$
+		requires = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/requirements$
+		resources = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/ResourceRates$
+        
+		crew_operate = True
+		hide_when_unavailable = True
+    }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[RP0-SupersonicHigh2]]:NEEDS[FeatureScience]:FOR[RP-0-Kerbalism]
+{
+	@baseValue = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/value$
+	@dataScale = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+  	{
+   		// sample mass in tons. if undefined or 0, the experiment produce a file
+    	SampleMass = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/SampleMass$
+	    // Body restrictions, multiple lines allowed (just don't use confictiong combinations).
+	    BodyAllowed = HomeBody
+		IncludeExperiment = #$@KERBALISM_CREW_EXPERIMENTS/RP0-SupersonicHigh2/IncludeExperiment$
+ 	}
+}
+

--- a/GameData/KerbalismConfig/System/Science/NewExperiments.cfg
+++ b/GameData/KerbalismConfig/System/Science/NewExperiments.cfg
@@ -32,29 +32,6 @@
 //   }
 
 // ============================================================================
-// Telemetry
-// ============================================================================
-//Supersonic Telemetry
-EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
-{
-    id = RP0telemetry2
-    title = Supersonic Flight Analysis
-    baseValue = 2
-    scienceCap = 2
-    dataScale = 2
-	
-    requireAtmosphere = False
-    situationMask = 12
-    biomeMask = 0
-
-    RESULTS
-    {
-        default = Basic telemetry and operational data from the vessel are recorded.
-		default = All systems are performing nominally.
-    }
-}
-
-// ============================================================================
 // BioSample
 // ============================================================================
 //BioSample tier 2: dogs and small animals
@@ -544,6 +521,87 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
 // ============================================================================
 // Crew Experiments
 // ============================================================================
+//Cockpits
+EXPERIMENT_DEFINITION
+{
+    id = RP0-SupersonicLow1
+    title = Supersonic flight
+    baseValue = 15
+    scienceCap = 15
+    dataScale = 5
+    situationMask = 4
+    biomeMask = 0
+    description = 
+    mass = 0.004
+    cost = 0
+    tags = Cockpit
+    minCrew = 1
+    celestialBodies = Earth
+    RESULTS
+    {
+        default = 
+    }
+}
+EXPERIMENT_DEFINITION
+{
+    id = RP0-SupersonicLow2
+    title = Mach 2 flight
+    baseValue = 20
+    scienceCap = 20
+    dataScale = 5
+    situationMask = 4
+    biomeMask = 0
+    description = 
+    mass = 0.004
+    cost = 0
+    tags = Cockpit
+    minCrew = 1
+    celestialBodies = Earth
+    RESULTS
+    {
+        default = 
+    }
+}
+EXPERIMENT_DEFINITION
+{
+    id = RP0-SupersonicHigh1
+    title = High altitude flight
+    baseValue = 20
+    scienceCap = 20
+    dataScale = 5
+    situationMask = 8
+    biomeMask = 0
+    description = 
+    mass = 0.004
+    cost = 0
+    tags = Cockpit
+    minCrew = 1
+    celestialBodies = Earth
+    RESULTS
+    {
+        default = 
+    }
+}
+EXPERIMENT_DEFINITION
+{
+    id = RP0-SupersonicHigh2
+    title = Hypersonic flight
+    baseValue = 20
+    scienceCap = 20
+    dataScale = 5
+    situationMask = 8
+    biomeMask = 0
+    description = 
+    mass = 0.004
+    cost = 0
+    tags = Cockpit
+    minCrew = 1
+    celestialBodies = Earth
+    RESULTS
+    {
+        default = 
+    }
+}
 //Basic Capsules
 EXPERIMENT_DEFINITION
 {

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
@@ -44,18 +44,6 @@ KERBALISM_EXPERIMENT_VALUES
 		ResourceRates = 
 		IncludeExperiment = 
 	}
-	RP0telemetry2 //atmospheric, supersonic
-	{
-		ECCost = 0.0001
-		size = 0.0007875 //3.5 b/s
-		SampleMass = 0 // a file, not a sample
-		value = 10
-		duration = 1800 //30 minutes
-		requirements = SurfaceSpeedMin:343
-		ResourceRates = 
-		IncludeExperiment = 
-	}
-	
 	//Temperature
 	temperatureScan
 	{

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
@@ -39,8 +39,8 @@
 	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/RP0photos1/value$
 	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/RP0photos1/size$
 	@dataScale /= #$baseValue$
-	%situationMask = 20
-	%biomeMask = 20
+	%situationMask = 24
+	%biomeMask = 24
 	KERBALISM_EXPERIMENT
   	{
    		// sample mass in tons. if undefined or 0, the experiment produce a file

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/bioSample.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/bioSample.cfg
@@ -35,7 +35,7 @@
 	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/RP0bioScan1/value$
 	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/RP0bioScan1/size$
 	@dataScale /= #$baseValue$
-	@situationMask = 48
+	@situationMask = 56
 	@biomeMask = 0
 	KERBALISM_EXPERIMENT
   	{
@@ -78,6 +78,7 @@
 	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/RP0bioScan2/value$
 	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/RP0bioScan2/size$
 	@dataScale /= #$baseValue$
+	@situationMask = 48
 	@biomeMask = 0
 	KERBALISM_EXPERIMENT
   	{

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/telemetryAnalysis.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/telemetryAnalysis.cfg
@@ -46,46 +46,6 @@
 }
 
 // ============================================================================
-// Telemetry 2
-// ============================================================================
-@PART[*]:HAS[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0telemetry2]]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
-{
-	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0telemetry2]]	{}
-	MODULE
-	{
-		name = Experiment
-		experiment_id = RP0telemetry2
-	}
-}
-
-@PART[*]:HAS[@MODULE[Experiment]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
-{
-	@MODULE[Experiment]:HAS[#experiment_id[RP0telemetry2]]
-	{
-		%ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/ECCost$
-		%data_rate = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/size$
-		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/duration$
-		%requires = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/requirements$
-		%resources = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/ResourceRates$
-		hide_when_unavailable = true
-		%experiment_desc = Supersonic and hypersonic flight study.
-	}
-}
-
-@EXPERIMENT_DEFINITION:HAS[#id[RP0telemetry2]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
-{
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/size$
-	@dataScale /= #$baseValue$
-	KERBALISM_EXPERIMENT
-  	{
-   		// sample mass in tons. if undefined or 0, the experiment produce a file
-    	SampleMass = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/SampleMass$
-		IncludeExperiment = #$@KERBALISM_EXPERIMENT_VALUES/RP0telemetry2/IncludeExperiment$
-  	}
-}
-
-// ============================================================================
 // Add experiment to parts
 // ============================================================================
 @PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism]
@@ -93,7 +53,7 @@
 	MODULE
 	{
 		name = ModuleScienceExperiment		
-		experimentID = RP0telemetry2
+		experimentID = RP0telemetry1
 
 		experimentActionName = Analyze Telemetry
 		resetActionName = Discard Telemetry


### PR DESCRIPTION
* Update Film Photography1 experiment to fit changes in RP-0

* Add Crewed science to all cockpits, and a set of 4 supersonic experiments

* Fix the tech limitations to the experiments

* Add the experiment definitions in NewExperiments and tweak velocities

* Fix a few typos/bugs and add the new X-1 cockpit

* Remove altitude requirement from flying high crewed experiments

Given the situation mask already does that better.

* Change speed requirements to fit the required altitudes

* Remove uncrewed supersonic analysis and add flying high to bio and photo

* Recover the patch adding telemetry to all command modules

Co-authored-by: leorjorge <leonardorejorge@gmail.com>